### PR TITLE
feat: publish message async with return value

### DIFF
--- a/src/TinyIpc/Messaging/TinyMessageBus.Tests.cs
+++ b/src/TinyIpc/Messaging/TinyMessageBus.Tests.cs
@@ -129,4 +129,23 @@ public class TinyMessageBusTests
 		await messageBus.PublishAsync(Encoding.UTF8.GetBytes("lorem"));
 		await messageBus.PublishAsync(Encoding.UTF8.GetBytes("ipsum"));
 	}
+
+	[Fact]
+	public async Task ReturnValueTest()
+	{
+		using var messagebus1 = new TinyMessageBus("ReturnValueTest");
+		using var messagebus2 = new TinyMessageBus("ReturnValueTest");
+
+		messagebus2.MessageReceived += async (s, e) =>
+		{
+			await Task.Delay(500);
+			var message = Encoding.UTF8.GetString(e.Message.ToArray());
+			e.TrySetResult($"Return from MessageReceived event: {message}");
+		};
+
+		var result = await messagebus1.PublishAsyncWithReturn(Encoding.UTF8.GetBytes("lorem"));
+		result.ShouldBe($"Return from MessageReceived event: lorem");
+
+		TinyMessageBus.m_tcs.Count.ShouldBe(0);
+	}
 }

--- a/src/TinyIpc/Messaging/TinyMessageReceivedEventArgs.cs
+++ b/src/TinyIpc/Messaging/TinyMessageReceivedEventArgs.cs
@@ -8,4 +8,33 @@ public class TinyMessageReceivedEventArgs : EventArgs
 	{
 		Message = message;
 	}
+
+
+	private readonly TaskCompletionSource<object>? m_task_source;
+	private readonly Guid? m_task_id;
+
+	public TinyMessageReceivedEventArgs(IReadOnlyList<byte> message, Guid id, TaskCompletionSource<object> source)
+		: this(message)
+	{
+		m_task_source = source;
+		m_task_id = id;
+	}
+
+	public void TrySetResult(object value)
+	{
+		m_task_source?.TrySetResult(value);
+		TinyMessageBus.ExpireTaskCompletionSource(m_task_id);
+	}
+
+	public void TrySetException(Exception exception)
+	{
+		m_task_source?.TrySetException(exception);
+		TinyMessageBus.ExpireTaskCompletionSource(m_task_id);
+	}
+
+	public void TrySetCanceled()
+	{
+		m_task_source?.TrySetCanceled();
+		TinyMessageBus.ExpireTaskCompletionSource(m_task_id);
+	}
 }


### PR DESCRIPTION
I'm not sure what I'm doing is against the original functionality.

usage:

```cs
using var messagebus1 = new TinyMessageBus("ReturnValueTest");
using var messagebus2 = new TinyMessageBus("ReturnValueTest");

messagebus2.MessageReceived += async (s, e) =>
{
	await Task.Delay(500);
	var message = Encoding.UTF8.GetString(e.Message.ToArray());
	e.TrySetResult($"Return from MessageReceived event: {message}");
};

var result = await messagebus1.PublishAsyncWithReturn(Encoding.UTF8.GetBytes("lorem"));
result.ShouldBe($"Return from MessageReceived event: lorem");
```

Now you can publish a message with callback.